### PR TITLE
Pickle data only if necessary

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,12 @@
 Change log
 ==========
 
+2024.10.31
+--------
+
+* Added support for raw data - all [BSON](https://www.mongodb.com/docs/manual/reference/bson-types/) compatible data stored in Mongo unpickled
+* **BREAKING**: Updated `cache.incr(key)` method - only works with raw data ([BSON Types](https://www.mongodb.com/docs/manual/reference/bson-types/))
+
 2023.10.4
 --------
 

--- a/django_cache_with_mongodb/__init__.py
+++ b/django_cache_with_mongodb/__init__.py
@@ -239,7 +239,7 @@ class MongoDBCache(BaseCache):
             }
         )
         for result in data:
-            if "encoded_data" in result:
+            if "data" in result:
                 unencoded = base64.decodebytes(result["data"])
                 unpickled = pickle.loads(unencoded)
                 out[parsed_keys[result["key"]]] = unpickled

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-cache-with-mongodb',
-    version='2023.10.4',
+    version='2024.10.31',
     packages=['django_cache_with_mongodb'],
     package_dir={'django_cache_with_mongodb': 'django_cache_with_mongodb'},
     provides=['django_cache_with_mongodb'],


### PR DESCRIPTION
Fix #4

- Try to save raw data and pickle if failed.
- Update `incr` method with `find_one_and_update` pymongo method. Potentially breaking change, only works with raw data.

Needs to be tested.