### PR TITLE
Change collStats casing so cache works with DocumentDB

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 Change log
 ==========
 
+2024.11.27
+--------
+
+* Updated usage of `collstats` to `collStats` for better support with MongoDB compatible databases
+
 2024.10.31
 --------
 

--- a/django_cache_with_mongodb/__init__.py
+++ b/django_cache_with_mongodb/__init__.py
@@ -253,7 +253,7 @@ class MongoDBCache(BaseCache):
         key = self.make_key(key, version)
         self.validate_key(key)
         coll = self._get_collection()
-        if not "capped" in self._db.command("collstats", self._collection_name):
+        if not "capped" in self._db.command("collStats", self._collection_name):
             coll.delete_one({"key": key})
         else:
             coll.update_one({"key": key}, {"$set": {"expires": timezone.now()}})
@@ -338,7 +338,7 @@ class MongoDBCache(BaseCache):
     @reconnect()
     def clear(self):
         coll = self._get_collection()
-        collstats = self._db.command("collstats", self._collection_name)
+        collstats = self._db.command("collStats", self._collection_name)
         if not "capped" in collstats or not collstats["capped"]:
             coll.delete_many({})
         else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-cache-with-mongodb',
-    version='2024.10.31',
+    version='2024.11.27',
     packages=['django_cache_with_mongodb'],
     package_dir={'django_cache_with_mongodb': 'django_cache_with_mongodb'},
     provides=['django_cache_with_mongodb'],


### PR DESCRIPTION
We have noticed an issue when using AWS DocumentDB instead of MongoDB where `collstats` is not supported. Changing to `collStats` fixes this. Both of these seem to work with MongoDB.